### PR TITLE
WIP: First Cut - this doesn't work yet - a work-in-progress.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src/main/resources"/>
+	<classpathentry kind="src" path="src/test/scala"/>
+	<classpathentry kind="src" path="src/test/resources"/>
+	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
+	<classpathentry kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:./lib_managed/docs/org.scala-lang.modules/scala-xml_2.12/scala-xml_2.12-1.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib_managed/bundles/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1.jar" sourcepath="lib_managed/srcs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:./lib_managed/docs/org.scala-lang.modules/scala-parser-combinators_2.12/scala-parser-combinators_2.12-1.1.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib_managed/jars/com.ibm.icu/icu4j/icu4j-62.1.jar" sourcepath="lib_managed/srcs/com.ibm.icu/icu4j/icu4j-62.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:./lib_managed/docs/com.ibm.icu/icu4j/icu4j-62.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib_managed/jars/xerces/xercesImpl/xercesImpl-2.12.0.jar" sourcepath="lib_managed/srcs/xerces/xercesImpl/xercesImpl-2.12.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:./lib_managed/docs/xerces/xercesImpl/xercesImpl-2.12.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib_managed/jars/xml-apis/xml-apis/xml-apis-1.4.01.jar" sourcepath="lib_managed/srcs/xml-apis/xml-apis/xml-apis-1.4.01-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:./lib_managed/docs/xml-apis/xml-apis/xml-apis-1.4.01-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib_managed/jars/xml-resolver/xml-resolver/xml-resolver-1.2.jar" sourcepath="lib_managed/srcs/xml-resolver/xml-resolver/xml-resolver-1.2-sources.jar"/>
+	<classpathentry kind="lib" path="lib_managed/jars/commons-io/commons-io/commons-io-2.6.jar" sourcepath="lib_managed/srcs/commons-io/commons-io/commons-io-2.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:./lib_managed/docs/commons-io/commons-io/commons-io-2.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib_managed/jars/jline/jline/jline-2.14.6.jar" sourcepath="lib_managed/srcs/jline/jline/jline-2.14.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:./lib_managed/docs/jline/jline/jline-2.14.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib_managed/jars/org.jdom/jdom2/jdom2-2.0.6.jar" sourcepath="lib_managed/srcs/org.jdom/jdom2/jdom2-2.0.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:./lib_managed/docs/org.jdom/jdom2/jdom2-2.0.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib_managed/bundles/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0.jar" sourcepath="lib_managed/srcs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:./lib_managed/docs/com.fasterxml.woodstox/woodstox-core/woodstox-core-5.1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib_managed/bundles/org.codehaus.woodstox/stax2-api/stax2-api-4.1.jar" sourcepath="lib_managed/srcs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:./lib_managed/docs/org.codehaus.woodstox/stax2-api/stax2-api-4.1-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib_managed/bundles/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6.jar" sourcepath="lib_managed/srcs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:./lib_managed/docs/com.fasterxml.jackson.core/jackson-core/jackson-core-2.9.6-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib_managed/jars/junit/junit/junit-4.12.jar" sourcepath="lib_managed/srcs/junit/junit/junit-4.12-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:./lib_managed/docs/junit/junit/junit-4.12-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib_managed/jars/org.hamcrest/hamcrest-core/hamcrest-core-1.3.jar" sourcepath="lib_managed/srcs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:./lib_managed/docs/org.hamcrest/hamcrest-core/hamcrest-core-1.3-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib_managed/jars/com.novocode/junit-interface/junit-interface-0.11.jar" sourcepath="lib_managed/srcs/com.novocode/junit-interface/junit-interface-0.11-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:./lib_managed/docs/com.novocode/junit-interface/junit-interface-0.11-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib_managed/jars/org.scala-sbt/test-interface/test-interface-1.0.jar" sourcepath="lib_managed/srcs/org.scala-sbt/test-interface/test-interface-1.0-sources.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:./lib_managed/docs/org.scala-sbt/test-interface/test-interface-1.0-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-core"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-io"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-runtime1-unparser"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-lib"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/daffodil-tdml-processor"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+/bin/
+.cache
+bin
+lib_managed
+target
+project/
+.cache-tests
+.cache-main

--- a/.project
+++ b/.project
@@ -1,0 +1,13 @@
+<projectDescription>
+  <name>cobol1</name>
+  <buildSpec>
+    <buildCommand>
+      <name>org.scala-ide.sdt.core.scalabuilder</name>
+    </buildCommand>
+  </buildSpec>
+  <natures>
+    <nature>org.scala-ide.sdt.core.scalanature</nature>
+    <nature>org.eclipse.jdt.core.javanature</nature>
+  </natures>
+  <linkedResources> </linkedResources>
+</projectDescription>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# Cobol
-Small Cobol data examples
+
+Cobol Examples
+
+Uses a mixture of types (strings, numbers, dates), Cobol representations - packed and zoned decimal, virtual decimal points.
+
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,28 @@
+lazy val root = (project in file(".")).
+  settings(
+    inThisBuild(List(
+      organization := "com.tresys",
+      version      := "0.0.1-SNAPSHOT",
+      scalaVersion := "2.12.6",
+      crossPaths := false,
+      retrieveManaged := true, // important so sbt eclipse doesn't put homedir paths in .classpath
+      testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")
+      // resolvers += "Apache Daffodil (incubating)" at "https://repository.apache.org/content/repositories/orgapachedaffodil-1009/"
+    )),
+    name := "cobol1",
+    libraryDependencies := Seq(
+      "org.apache.daffodil" %% "daffodil-tdml-processor" % "2.4.0" % "test",
+      "junit" % "junit" % "4.12" % "test",
+      "com.novocode" % "junit-interface" % "0.11" % "test",
+    )
+  )
+  //
+  // Uncomment this line below to run against IBM DFDL.
+  // You need to have IBM DFDL installed and the IBM DFDL Cross Tester
+  //
+  // Note: This requires a 2.3.0 release of daffodil. (See version of daffodil-tdml-processor above)
+  // or a development snapshot (e.g., version "latest.integration")
+  // 
+  //.settings(IBMDFDLCrossTesterPlugin.settings)
+
+

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/src/main/resources/com/tresys/cobol1/xsd/cobol1.dfdl.xsd
+++ b/src/main/resources/com/tresys/cobol1/xsd/cobol1.dfdl.xsd
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+    xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
+    targetNamespace="http://example.com"
+    xmlns:tns="http://example.com"
+    xmlns:ex="http://example.com"
+    xmlns:fn="http://www.w3.org/2005/xpath-functions" >
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <xs:element name="RECORDS" dfdl:lengthKind="implicit">
+    <xs:complexType>
+      <xs:sequence >
+        <xs:element maxOccurs="unbounded" ref="tns:MY-RECORD"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:defineFormat name="cobol1Format">
+        <dfdl:format ref="tns:GeneralFormatPortable"
+          alignment="1" 
+          alignmentUnits="bytes" 
+          binaryBooleanFalseRep="0" 
+          binaryBooleanTrueRep="1" 
+          binaryDecimalVirtualPoint="0" 
+          binaryFloatRep="ieee" 
+          binaryNumberCheckPolicy="strict" 
+          binaryPackedSignCodes="C D F C" 
+          byteOrder="bigEndian" 
+          calendarCenturyStart="53" 
+          calendarCheckPolicy="strict" 
+          calendarFirstDayOfWeek="Monday"           
+          calendarLanguage="en-US" 
+          calendarObserveDST="yes" 
+          calendarTimeZone="" 
+          choiceLengthKind="implicit" 
+          decimalSigned="yes" 
+          encoding="ebcdic-cp-us"  
+          fillByte="%#r00;" 
+          lengthKind="explicit" 
+          lengthUnits="bytes" 
+          occursCountKind="implicit" 
+          representation="binary"  
+          textBooleanFalseRep="%#r01;" 
+          textBooleanJustification="left" 
+          textBooleanPadCharacter="%SP;" 
+          textBooleanTrueRep="%#r00;" 
+          textCalendarJustification="left" 
+          textCalendarPadCharacter="0"
+          textNumberJustification="right" 
+          textNumberPadCharacter="0" 
+          textNumberRep="zoned" 
+          textNumberRounding="pattern" 
+          textNumberRoundingMode="roundUp" 
+          textPadKind="none" 
+          textStandardBase="10"
+          textStringJustification="left" 
+          textStringPadCharacter="%SP;" 
+          textTrimKind="none" 
+          textZonedSignStyle="asciiStandard"  
+          >
+        </dfdl:format>
+      </dfdl:defineFormat>
+      <dfdl:format ref="tns:cobol1Format"/>
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="MY-RECORD" dfdl:lengthKind="implicit">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:annotation>
+          <xs:documentation>
+<![CDATA[
+01 MY-RECORD. 
+ 05 CLAIM-NUMBER             PIC X(19). 
+ 05 ADMISSION-DATE           PACKED-DECIMAL PIC S9(7). 
+ 05 FROM-DATE                PACKED-DECIMAL PIC S9(7). 
+ 05 THRU-DATE                PACKED-DECIMAL PIC S9(7). 
+ 05 DISCHARGE-DATE           PACKED-DECIMAL PIC S9(7). 
+ 05 FULL-DAYS                PACKED-DECIMAL PIC S9(5). 
+ 05 COINSURANCE-DAYS         BINARY         PIC 9(4). 
+ 05 LIFETIME-RES-DAYS        BINARY         PIC 9(6). 
+ 05 INTERMEDIARY-NUM         BINARY         PIC 9(10). 
+ 05 PROVIDER                                PIC X(13). 
+ 05 INPATIENT-DED            PACKED-DECIMAL PIC S9(4)V99.
+ 05 BLOOD-DED                PACKED-DECIMAL PIC S9(4)V99.
+ 05 TOTAL-CHARGES      PIC S9(7)V99 DISPLAY SIGN LEADING.
+ 05 PATIENT-STATUS                          PIC X(2). 
+ 05 BLOOD-PINTS-FURNISHED    BINARY         PIC 9(5). 
+ 05 BLOOD-PINTS-REPLACED     BINARY         PIC 9(4). 
+ 05 SEQUENCE-COUNTER         BINARY         PIC 9(3). 
+ 05 TRANSACTION-IND                         PIC 9. 
+ 05 BILL-SOURCE                             PIC 9. 
+ 05 BENEFITS-EXHAUST-IND                    PIC 9. 
+ 05 BENEFITS-PAY-IND                        PIC 9. 
+ 05 AUTO-ADJUSTMENT-IND                     PIC X. 
+ 05 INTERMEDIARY-CTRL-NUM                   PIC X(23).
+]]>
+          </xs:documentation>
+        </xs:annotation>
+        <xs:element name="CLAIM-NUMBER" type="xs:string" dfdl:length="19" />
+        <xs:element name="ADMISSION-DATE" type="tns:signedPacked7DigitDate" />
+        <xs:element name="FROM-DATE" type="tns:signedPacked7DigitDate" />
+        <xs:element name="THRU-DATE" type="tns:signedPacked7DigitDate" />
+        <xs:element name="DISCHARGE-DATE" type="tns:signedPacked7DigitDate" />
+        <xs:element name="FULL-DAYS" type="tns:signedPackedInt5Digits" />
+        <xs:element name="COINSURANCE-DAYS" type="tns:binary4Digits" />
+        <xs:element name="LIFETIME-RES-DAYS" type="tns:binary6Digits" />
+        <xs:element name="INTERMEDIARY-NUM" type="tns:binary10Digits" />
+        <xs:element name="PROVIDER" type="xs:string" dfdl:length="13" />
+        <xs:element name="INPATIENT-DED" type="tns:packedMoney4Digits" />
+        <xs:element name="BLOOD-DED" type="tns:packedMoney4Digits" />
+        <xs:element name="TOTAL-CHARGES" type="tns:displayMoney7Digits" />
+        <xs:element name="PATIENT-STATUS" type="xs:string" dfdl:length="2" />
+        <xs:element name="BLOOD-PINTS-FURNISHED" type="tns:binary5Digits" />
+        <xs:element name="BLOOD-PINTS-REPLACED" type="tns:binary4Digits" />
+        <xs:element name="SEQUENCE-COUNTER" type="tns:binary3Digits" />
+        <xs:element name="BILL-SOURCE" type="tns:display1Digit" />
+        <xs:element name="BENEFITS-EXHAUST-IND" type="tns:display1Digit" />
+        <xs:element name="BENEFITS-PAY-IND" type="tns:display1Digit" />
+        <xs:element name="AUTO-ADJUSTMENT-IND" type="xs:string" dfdl:length="1" />
+        <xs:element name="INTERMEDIARY-CTRL-NUM" type="xs:string" dfdl:length="23" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  
+  <!-- 
+    IBM DFDL doesn't support binaryCalendarRep="packed" so we have to 
+    hack around this using BCD, and surrounding things that create the 
+    leading 0 nibble, and trailing "C" nibble which would exist for packed.
+    -->
+  <xs:simpleType name="WORKAROUND_signedPacked7DigitDate" 
+    dfdl:alignmentUnits="bits"
+    dfdl:alignment="4"
+    dfdl:representation="binary"
+    dfdl:binaryCalendarRep="bcd"
+    dfdl:decimalSigned="yes" 
+    dfdl:length="3"
+    dfdl:lengthUnits="bytes" 
+    dfdl:calendarPattern="MMddyy" 
+    dfdl:calendarPatternKind="explicit">
+    <xs:restriction base="xs:date" />
+  </xs:simpleType>
+  
+  <!-- remove these if not using the BCD workaround -->
+  <xs:group name="skip0Nibble">
+    <xs:sequence dfdl:alignmentUnits="bits"
+    dfdl:alignment="4"
+    dfdl:fillByte="%#r00;"
+    dfdl:leadingSkip="4"/>
+  </xs:group>
+  
+   <xs:group name="skipCNibble">
+    <xs:sequence dfdl:alignmentUnits="bits"
+    dfdl:alignment="4"
+    dfdl:fillByte="%#rCC;"
+    dfdl:leadingSkip="4"/>
+  </xs:group>
+  
+  <!-- 
+  Original with "packed" rep
+   -->
+  <xs:simpleType name="signedPacked7DigitDate" 
+    dfdl:representation="binary"
+    dfdl:binaryCalendarRep="packed"
+    dfdl:decimalSigned="yes" 
+    dfdl:length="4" 
+    dfdl:calendarPattern="MMddyy" 
+    dfdl:calendarPatternKind="explicit">
+    <xs:restriction base="xs:date" />
+  </xs:simpleType>
+  
+  <xs:simpleType name="signedPackedInt5Digits" 
+    dfdl:representation="binary"
+    dfdl:binaryNumberRep="packed"
+    dfdl:decimalSigned="yes" 
+    dfdl:length="3" >
+    <xs:restriction base="xs:int" >
+      <xs:maxInclusive value="99999"/>
+      <xs:minInclusive value="-99999"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <!-- TBD Alignment requirements for binary numbers? -->
+  
+  <xs:simpleType name="binary3Digits" 
+    dfdl:representation="binary"
+    dfdl:binaryNumberRep="binary"
+    dfdl:length="2"> 
+    <xs:restriction base="xs:int">
+      <xs:maxInclusive value="999"/>
+      <xs:minInclusive value="-999"/>
+    </xs:restriction>
+  </xs:simpleType> 
+  
+  <xs:simpleType name="binary4Digits" 
+    dfdl:representation="binary"
+    dfdl:binaryNumberRep="binary"
+    dfdl:length="2"> 
+    <xs:restriction base="xs:int">
+      <xs:maxInclusive value="9999"/>
+      <xs:minInclusive value="-9999"/>
+    </xs:restriction>
+  </xs:simpleType>  
+  
+  <xs:simpleType name="binary5Digits" 
+    dfdl:representation="binary"
+    dfdl:binaryNumberRep="binary"
+    dfdl:length="4"> 
+    <xs:restriction base="xs:int" >
+      <xs:maxInclusive value="99999"/>
+      <xs:minInclusive value="-99999"/>
+    </xs:restriction>
+  </xs:simpleType> 
+  
+  <xs:simpleType name="binary6Digits" 
+    dfdl:representation="binary"
+    dfdl:binaryNumberRep="binary"
+    dfdl:length="4"> 
+    <xs:restriction base="xs:int" >
+      <xs:maxInclusive value="999999"/>
+      <xs:minInclusive value="-999999"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="binary10Digits" 
+    dfdl:representation="binary"
+    dfdl:binaryNumberRep="binary"
+    dfdl:length="8"> 
+    <xs:restriction base="xs:long" >
+      <xs:maxInclusive value="9999999999"/>
+      <xs:minInclusive value="-9999999999"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="packedMoney4Digits" 
+    dfdl:representation="binary"
+    dfdl:binaryNumberRep="packed"
+    dfdl:decimalSigned="yes" 
+    dfdl:length="4"
+    dfdl:binaryDecimalVirtualPoint="2">
+    <xs:restriction base="xs:decimal" >
+      <xs:maxInclusive value="9999.99"/>
+      <xs:minInclusive value="-9999.99"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+<!-- 
+  The type below is incorrect. It should be 10 bytes long and use an 
+  implied decimal point, i.e., the dfdl:textNumberPattern should be 
+  "+######0V00;-######0V00". However, this "V" is not implemented yet in 
+  Daffodil as of 2019-09-17.
+ -->
+  <xs:simpleType name="displayMoney7Digits" 
+    dfdl:representation="text"
+    dfdl:textNumberRep="standard"
+    dfdl:decimalSigned="yes"
+    dfdl:textNumberPattern="+######0.00;-######0.00" 
+    dfdl:length="11">
+    <xs:restriction base="xs:decimal" >
+      <xs:maxInclusive value="9999999.99"/>
+      <xs:minInclusive value="-9999999.99"/>
+    </xs:restriction>
+  </xs:simpleType>    
+  
+  <xs:simpleType name="display1Digit" 
+    dfdl:representation="text"
+    dfdl:textNumberRep="zoned"
+    dfdl:textNumberPattern="+0" 
+    dfdl:decimalSigned="no" 
+    dfdl:length="1">
+    <xs:restriction base="xs:unsignedInt" >
+      <xs:maxInclusive value="9"/>
+      <xs:minInclusive value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+</xs:schema>

--- a/src/test/resources/com/tresys/cobol1/tests.tdml
+++ b/src/test/resources/com/tresys/cobol1/tests.tdml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tdml:testSuite 
+ xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+ xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
+ xmlns:xs="http://www.w3.org/2001/XMLSchema"
+ xmlns:ex="http://example.com" 
+ xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+ defaultConfig="cfg"
+ defaultRoundTrip="onePass">
+ 
+  <tdml:defineConfig name="cfg">
+    <daf:tunables>
+      <daf:suppressSchemaDefinitionWarnings>
+        deprecatedPropertySeparatorPolicy
+        encodingErrorPolicyError
+        emptyElementParsePolicyError
+      </daf:suppressSchemaDefinitionWarnings>
+    </daf:tunables>
+  </tdml:defineConfig>
+
+  <tdml:unparserTestCase name="test1" model="com/tresys/cobol1/xsd/cobol1.dfdl.xsd">
+    <tdml:document>
+      <tdml:documentPart type="text" encoding="ebcdic-cp-us">1234567890123456789</tdml:documentPart>
+      <tdml:documentPart type="byte">0020161C</tdml:documentPart>
+      <tdml:documentPart type="byte">0020161C</tdml:documentPart>
+      <tdml:documentPart type="byte">0020161C</tdml:documentPart>
+      <tdml:documentPart type="byte">0020161C</tdml:documentPart>
+      <tdml:documentPart type="byte">99999C</tdml:documentPart>
+      <tdml:documentPart type="byte">270f</tdml:documentPart>
+      <tdml:documentPart type="byte">000f423f</tdml:documentPart>
+      <tdml:documentPart type="byte">00000002540be3ff</tdml:documentPart>
+      <tdml:documentPart type="text" encoding="ebcdic-cp-us">PROVIDER12345</tdml:documentPart>
+      <tdml:documentPart type="byte">0999999C</tdml:documentPart>
+      <tdml:documentPart type="byte">0999999C</tdml:documentPart>
+      <!-- 
+      The decimal point character in the string below should NOT be in the
+      data. It is there for now because Daffodil does not yet implement the "V"
+      character for dfdl:textNumberPattern indicating the location of an 
+      implied decimal point. 
+       -->
+      <tdml:documentPart type="text" encoding="ebcdic-cp-us">+9999999.99</tdml:documentPart>
+      
+      <tdml:documentPart type="text" encoding="ebcdic-cp-us">AA</tdml:documentPart>
+      <tdml:documentPart type="byte">0001869f</tdml:documentPart>
+      <tdml:documentPart type="byte">270f</tdml:documentPart>
+      <tdml:documentPart type="byte">03e7</tdml:documentPart>
+      <tdml:documentPart type="byte">F9</tdml:documentPart>
+      <tdml:documentPart type="byte">F8</tdml:documentPart>
+      <tdml:documentPart type="byte">F7</tdml:documentPart>
+      <tdml:documentPart type="text" encoding="ebcdic-cp-us">X</tdml:documentPart>
+      <tdml:documentPart type="text" encoding="ebcdic-cp-us">A12345678901234567890AB</tdml:documentPart>    
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset>
+          <ex:MY-RECORD>
+           <CLAIM-NUMBER>1234567890123456789</CLAIM-NUMBER>
+        <ADMISSION-DATE>1961-02-01</ADMISSION-DATE>
+        <FROM-DATE>1961-02-01</FROM-DATE>
+        <THRU-DATE>1961-02-01</THRU-DATE>
+        <DISCHARGE-DATE>1961-02-01</DISCHARGE-DATE>
+        <FULL-DAYS>99999</FULL-DAYS>
+        <COINSURANCE-DAYS>9999</COINSURANCE-DAYS>
+        <LIFETIME-RES-DAYS>999999</LIFETIME-RES-DAYS>
+        <INTERMEDIARY-NUM>9999999999</INTERMEDIARY-NUM>
+        <PROVIDER>PROVIDER12345</PROVIDER>
+        <INPATIENT-DED>9999.99</INPATIENT-DED>
+        <BLOOD-DED>9999.99</BLOOD-DED>
+        <TOTAL-CHARGES>9999999.99</TOTAL-CHARGES>
+        <PATIENT-STATUS>AA</PATIENT-STATUS>
+        <BLOOD-PINTS-FURNISHED>99999</BLOOD-PINTS-FURNISHED>
+        <BLOOD-PINTS-REPLACED>9999</BLOOD-PINTS-REPLACED>
+        <SEQUENCE-COUNTER>999</SEQUENCE-COUNTER>
+        <BILL-SOURCE>9</BILL-SOURCE>
+        <BENEFITS-EXHAUST-IND>8</BENEFITS-EXHAUST-IND>
+        <BENEFITS-PAY-IND>7</BENEFITS-PAY-IND>
+        <AUTO-ADJUSTMENT-IND>X</AUTO-ADJUSTMENT-IND>
+        <INTERMEDIARY-CTRL-NUM>A12345678901234567890AB</INTERMEDIARY-CTRL-NUM>
+          </ex:MY-RECORD>
+      </tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+    
+</tdml:testSuite>

--- a/src/test/scala/com/tresys/cobol1/tests.scala
+++ b/src/test/scala/com/tresys/cobol1/tests.scala
@@ -1,0 +1,20 @@
+
+package com.tresys.cobol1
+
+import org.junit.Test
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+
+object Tests {
+  lazy val runner = Runner("com/tresys/cobol1", "tests.tdml")
+
+  @AfterClass def shutdown: Unit = { runner.reset }
+
+}
+
+class Tests {
+  import Tests._
+
+  @Test def test1 { runner.runOneTest("test1") }
+
+}


### PR DESCRIPTION
Doesn't work in Daffodil for lack of "V" textNumberPattern feature.

Doesn't work in IBM DFDL for lack of binaryCalendarRep="packed" support. 
Also needs dfdl:calendarTimeZone="UTC" because "" is not accepted - this will require changing the test logical data to have "+00:00" on the dates. 