### PR TITLE
Update to use 'V' virtual decimal point and zoned trailing overpunched

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+/bin/
+.cache
+bin
+lib_managed
+target
+project/
+.cache-tests
+.cache-main
+/.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# Cobol
-Small Cobol data examples
+
+# COBOL Example(s)
+
+Uses a mixture of types (strings, numbers, dates), with [COBOL](https://en.wikipedia.org/wiki/COBOL) representations including packed decimal, zoned decimal, and virtual decimal points. 
+
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,49 @@
+name := "dfdl-cobol-examples"
+
+organization := "com.owl"
+
+version := "0.0.1-SNAPSHOT"
+
+scalaVersion := "2.12.17"
+ 
+libraryDependencies ++= Seq(
+  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.5.0-SNAPSHOT" % "test",
+  "junit" % "junit" % "4.13.2" % "test",
+  "com.github.sbt" % "junit-interface" % "0.13.3" % "test",
+  "org.apache.logging.log4j" % "log4j-core" % "2.19.0" % "test",
+)
+
+testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")
+
+crossPaths := false
+
+retrieveManaged := true
+
+useCoursier := false
+
+// To run against IBM DFDL, uncomment the line below so that
+// the ibm-dfdl-crosstester plugin will run.
+// Setup of the ibm-dfdl-crosstester is explained in the README.md
+// file of the github openDFDL ibm-dfdl-crosstester project.
+//
+// IBMDFDLCrossTesterPlugin.settings
+
+
+//
+// Use flatter simple folder structure.
+//
+// src directory contains all source files (they are distinguished by file types)
+// test directory contains all test files.
+//
+lazy val root = (project in file("."))
+  .settings(
+    Project.inConfig(Compile)(flattenSettings("src")),
+    Project.inConfig(Test)(flattenSettings("test")),
+  )
+
+def flattenSettings(name: String) = Seq(
+  unmanagedSourceDirectories := Seq(baseDirectory.value / name),
+  unmanagedResourceDirectories := unmanagedSourceDirectories.value,
+  unmanagedSources / includeFilter := "*.java" | "*.scala",
+  unmanagedResources / excludeFilter := (unmanagedSources / includeFilter).value,
+)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,2 @@
+sbt.version=1.8.0
+

--- a/src/cobol1.dfdl.xsd
+++ b/src/cobol1.dfdl.xsd
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns="http://www.w3.org/2001/XMLSchema"
+    xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
+    targetNamespace="http://example.com"
+    xmlns:tns="http://example.com"
+    xmlns:ex="http://example.com"
+    xmlns:fn="http://www.w3.org/2005/xpath-functions">
+
+  <include schemaLocation="cobolFormat1.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <!--
+      Use lengthKind explicit here because most of this file is definitions of
+      fixed length simple types. There are only a few complex types here, so we
+      put dfdl:lengthKind="implicit" on just those few.
+      -->
+      <dfdl:format ref="tns:cobolFormat1"
+        lengthKind="explicit"/>
+    </appinfo>
+  </annotation>
+
+  <element name="RECORDS" dfdl:lengthKind="implicit">
+    <complexType>
+      <sequence >
+        <element maxOccurs="unbounded" ref="tns:RECORD"/>
+      </sequence>
+    </complexType>
+  </element>
+
+  <element name="RECORD" type="tns:myRecordType" dfdl:lengthKind="implicit"/>
+
+  <complexType name="myRecordType">
+    <sequence>
+      <annotation>
+        <documentation>
+          <![CDATA[
+01 MY-RECORD. 
+ 05 CLAIM-NUMBER             PIC X(19). 
+ 05 ADMISSION-DATE           PIC X(6).
+ 05 FROM-DATE                PIC X(6).
+ 05 THRU-DATE                PIC X(6).
+ 05 DISCHARGE-DATE           PIC X(6).
+ 05 FULL-DAYS                PACKED-DECIMAL PIC S9(5). 
+ 05 COINSURANCE-DAYS         BINARY         PIC 9(4). 
+ 05 LIFETIME-RES-DAYS        BINARY         PIC 9(6). 
+ 05 INTERMEDIARY-NUM         BINARY         PIC 9(10). 
+ 05 PROVIDER                                PIC X(13). 
+ 05 INPATIENT-DED            PACKED-DECIMAL PIC S9(4)V99.
+ 05 BLOOD-DED                PACKED-DECIMAL PIC S9(4)V99.
+ 05 TOTAL-CHARGES      PIC S9(7)V99 DISPLAY SIGN LEADING.
+ 05 PATIENT-STATUS                          PIC X(2). 
+ 05 BLOOD-PINTS-FURNISHED    BINARY         PIC 9(5). 
+ 05 BLOOD-PINTS-REPLACED     BINARY         PIC 9(4). 
+ 05 SEQUENCE-COUNTER         BINARY         PIC 9(3). 
+ 05 TRANSACTION-IND                         PIC 9. 
+ 05 BILL-SOURCE                             PIC 9. 
+ 05 BENEFITS-EXHAUST-IND                    PIC 9. 
+ 05 BENEFITS-PAY-IND                        PIC 9. 
+ 05 AUTO-ADJUSTMENT-IND                     PIC X. 
+ 05 INTERMEDIARY-CTRL-NUM                   PIC X(23).
+]]>
+        </documentation>
+      </annotation>
+      <element name="CLAIM-NUMBER" type="xs:string" dfdl:length="19"/>
+      <element name="ADMISSION-DATE" type="tns:date6Chars"/>
+      <element name="FROM-DATE" type="tns:date6Chars"/>
+      <element name="THRU-DATE" type="tns:date6Chars"/>
+      <element name="DISCHARGE-DATE" type="tns:date6Chars"/>
+      <element name="FULL-DAYS" type="tns:signedPackedInt5Digits"/>
+      <element name="COINSURANCE-DAYS" type="tns:binary4Digits"/>
+      <element name="LIFETIME-RES-DAYS" type="tns:binary6Digits"/>
+      <element name="INTERMEDIARY-NUM" type="tns:binary10Digits"/>
+      <element name="PROVIDER" type="xs:string" dfdl:length="13"/>
+      <element name="INPATIENT-DED" type="tns:packedMoney4Digits"/>
+      <element name="BLOOD-DED" type="tns:packedMoney4Digits"/>
+      <element name="TOTAL-CHARGES" type="tns:displayMoney7Digits"/>
+      <element name="PATIENT-STATUS" type="xs:string" dfdl:length="2"/>
+      <element name="BLOOD-PINTS-FURNISHED" type="tns:binary5Digits"/>
+      <element name="BLOOD-PINTS-REPLACED" type="tns:binary4Digits"/>
+      <element name="SEQUENCE-COUNTER" type="tns:binary3Digits"/>
+      <element name="BILL-SOURCE" type="tns:display1Digit"/>
+      <element name="BENEFITS-EXHAUST-IND" type="tns:display1Digit"/>
+      <element name="BENEFITS-PAY-IND" type="tns:display1Digit"/>
+      <element name="AUTO-ADJUSTMENT-IND" type="xs:string" dfdl:length="1"/>
+      <element name="INTERMEDIARY-CTRL-NUM" type="xs:string" dfdl:length="23"/>
+    </sequence>
+  </complexType>
+
+  <simpleType name="date6Chars"
+              dfdl:representation="text"
+              dfdl:decimalSigned="yes"
+              dfdl:length="6">
+    <restriction base="xs:string" />
+  </simpleType>
+  
+  <simpleType name="signedPackedInt5Digits"
+    dfdl:representation="binary"
+    dfdl:binaryNumberRep="packed"
+    dfdl:decimalSigned="yes" 
+    dfdl:length="3" >
+    <restriction base="xs:int" >
+      <maxInclusive value="99999"/>
+      <minInclusive value="-99999"/>
+    </restriction>
+  </simpleType>
+  
+  <!-- TBD Alignment requirements for COBOL binary numbers? -->
+  
+  <simpleType name="binary3Digits"
+    dfdl:representation="binary"
+    dfdl:binaryNumberRep="binary"
+    dfdl:length="2"> 
+    <restriction base="xs:int">
+      <maxInclusive value="999"/>
+      <minInclusive value="-999"/>
+    </restriction>
+  </simpleType>
+  
+  <simpleType name="binary4Digits"
+    dfdl:representation="binary"
+    dfdl:binaryNumberRep="binary"
+    dfdl:length="2"> 
+    <restriction base="xs:int">
+      <maxInclusive value="9999"/>
+      <minInclusive value="-9999"/>
+    </restriction>
+  </simpleType>
+  
+  <simpleType name="binary5Digits"
+    dfdl:representation="binary"
+    dfdl:binaryNumberRep="binary"
+    dfdl:length="4"> 
+    <restriction base="xs:int" >
+      <maxInclusive value="99999"/>
+      <minInclusive value="-99999"/>
+    </restriction>
+  </simpleType>
+  
+  <simpleType name="binary6Digits"
+    dfdl:representation="binary"
+    dfdl:binaryNumberRep="binary"
+    dfdl:length="4"> 
+    <restriction base="xs:int" >
+      <maxInclusive value="999999"/>
+      <minInclusive value="-999999"/>
+    </restriction>
+  </simpleType>
+  
+  <simpleType name="binary10Digits"
+    dfdl:representation="binary"
+    dfdl:binaryNumberRep="binary"
+    dfdl:length="8"> 
+    <restriction base="xs:long" >
+      <maxInclusive value="9999999999"/>
+      <minInclusive value="-9999999999"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="packedMoney4Digits"
+    dfdl:representation="binary"
+    dfdl:binaryNumberRep="packed"
+    dfdl:decimalSigned="yes" 
+    dfdl:length="4"
+    dfdl:binaryDecimalVirtualPoint="2">
+    <restriction base="xs:decimal" >
+      <maxInclusive value="9999.99"/>
+      <minInclusive value="-9999.99"/>
+    </restriction>
+  </simpleType>
+
+
+  <!--
+  This type uses dfdl:textNumberPattern character 'V' for virtual decimal point
+
+  It is zoned decimal with trailing overpunched sign.
+
+  This is not officially available until Daffodil 3.5.0
+  -->
+
+  <simpleType
+    name="displayMoney7Digits"
+    dfdl:representation="text"
+    dfdl:textNumberRep="zoned"
+    dfdl:textZonedSignStyle="asciiStandard"
+    dfdl:decimalSigned="yes"
+    dfdl:textNumberPattern="0000000V00+"
+    dfdl:length="9">
+    <restriction base="xs:decimal" >
+      <maxInclusive value="9999999.99"/>
+      <minInclusive value="-9999999.99"/>
+    </restriction>
+  </simpleType>
+  
+  <simpleType name="display1Digit"
+    dfdl:representation="text"
+    dfdl:textNumberRep="zoned"
+    dfdl:textNumberPattern="+0" 
+    dfdl:decimalSigned="no" 
+    dfdl:length="1">
+    <restriction base="xs:unsignedInt" >
+      <maxInclusive value="9"/>
+      <minInclusive value="0"/>
+    </restriction>
+  </simpleType>
+  
+</schema>

--- a/src/cobolFormat1.dfdl.xsd
+++ b/src/cobolFormat1.dfdl.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  targetNamespace="http://example.com"
+  xmlns:tns="http://example.com"
+  xmlns:ex="http://example.com"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions">
+
+  <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:defineFormat name="cobolFormat1">
+        <dfdl:format ref="tns:GeneralFormatPortable"
+                     binaryBooleanFalseRep="0"
+                     binaryBooleanTrueRep="1"
+                     binaryDecimalVirtualPoint="0"
+                     binaryNumberCheckPolicy="strict"
+                     binaryPackedSignCodes="C D F C"
+                     byteOrder="bigEndian"
+                     calendarLanguage="en-US"
+                     decimalSigned="yes"
+                     encoding="ebcdic-cp-us"
+                     fillByte="%#r00;"
+                     representation="binary"
+                     textBooleanFalseRep="%#r01;"
+                     textBooleanJustification="left"
+                     textBooleanTrueRep="%#r00;"
+                     textCalendarPadCharacter="0"
+                     textNumberJustification="right"
+                     textNumberPadCharacter="0"
+                     textNumberRep="zoned"
+                     textNumberRounding="pattern"
+                     textNumberRoundingMode="roundUp"
+                     textPadKind="none"
+                     textStandardBase="10"
+                     textStandardZeroRep=""
+                     textTrimKind="none"
+                     textZonedSignStyle="asciiStandard">
+        </dfdl:format>
+      </dfdl:defineFormat>
+      <dfdl:format ref="tns:cobol1Format"/>
+    </appinfo>
+  </annotation>
+</schema>

--- a/test/tests.scala
+++ b/test/tests.scala
@@ -1,0 +1,21 @@
+
+package com.owlcyberdefense.cobol1
+
+import org.junit.Test
+import org.apache.daffodil.tdml.Runner
+import org.junit.AfterClass
+
+object Tests {
+  lazy val runner = Runner("", "tests.tdml")
+
+  @AfterClass def shutdown: Unit = { runner.reset }
+
+}
+
+class Tests {
+  import Tests._
+
+  @Test def testCobol1 { runner.runOneTest("testCobol1") }
+
+
+}

--- a/test/tests.tdml
+++ b/test/tests.tdml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testSuite
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:ex="http://example.com"
+  xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+  defaultConfig="cfg"
+  defaultRoundTrip="onePass">
+
+  <defineConfig name="cfg">
+    <daf:tunables>
+      <!--
+      We suppress encodingErrorPolicyError because this is a portable schema that should work with IBM DFDL, but
+      Daffodil emits a warning about every use of dfdl:encodingErrorPolicy='error'.
+      -->
+      <daf:suppressSchemaDefinitionWarnings>
+        encodingErrorPolicyError
+      </daf:suppressSchemaDefinitionWarnings>
+    </daf:tunables>
+  </defineConfig>
+
+  <parserTestCase name="testCobol1" model="cobol1.dfdl.xsd">
+    <document>
+      <documentPart type="text" encoding="ebcdic-cp-us">1234567890123456789</documentPart>
+      <documentPart type="text" encoding="ebcdic-cp-us">020161</documentPart>
+      <documentPart type="text" encoding="ebcdic-cp-us">020161</documentPart>
+      <documentPart type="text" encoding="ebcdic-cp-us">020161</documentPart>
+      <documentPart type="text" encoding="ebcdic-cp-us">123199</documentPart>
+      <documentPart type="byte">99999C</documentPart>
+      <documentPart type="byte">270f</documentPart>
+      <documentPart type="byte">000f423f</documentPart>
+      <documentPart type="byte">00000002540be3ff</documentPart>
+      <documentPart type="text" encoding="ebcdic-cp-us">PROVIDER12345</documentPart>
+      <documentPart type="byte">0999999C</documentPart>
+      <documentPart type="byte">0999999C</documentPart>
+      <documentPart type="text" encoding="ebcdic-cp-us">99999999y</documentPart>
+      <documentPart type="text" encoding="ebcdic-cp-us">AA</documentPart>
+      <documentPart type="byte">0001869f</documentPart>
+      <documentPart type="byte">270f</documentPart>
+      <documentPart type="byte">03e7</documentPart>
+      <documentPart type="byte">F9</documentPart>
+      <documentPart type="byte">F8</documentPart>
+      <documentPart type="byte">F7</documentPart>
+      <documentPart type="text" encoding="ebcdic-cp-us">X</documentPart>
+      <documentPart type="text" encoding="ebcdic-cp-us">A12345678901234567890AB</documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:RECORD xmlns="">
+          <CLAIM-NUMBER>1234567890123456789</CLAIM-NUMBER>
+          <ADMISSION-DATE>020161</ADMISSION-DATE>
+          <FROM-DATE>020161</FROM-DATE>
+          <THRU-DATE>020161</THRU-DATE>
+          <DISCHARGE-DATE>123199</DISCHARGE-DATE>
+          <FULL-DAYS>99999</FULL-DAYS>
+          <COINSURANCE-DAYS>9999</COINSURANCE-DAYS>
+          <LIFETIME-RES-DAYS>999999</LIFETIME-RES-DAYS>
+          <INTERMEDIARY-NUM>9999999999</INTERMEDIARY-NUM>
+          <PROVIDER>PROVIDER12345</PROVIDER>
+          <INPATIENT-DED>9999.99</INPATIENT-DED>
+          <BLOOD-DED>9999.99</BLOOD-DED>
+          <TOTAL-CHARGES>-9999999.99</TOTAL-CHARGES>
+          <PATIENT-STATUS>AA</PATIENT-STATUS>
+          <BLOOD-PINTS-FURNISHED>99999</BLOOD-PINTS-FURNISHED>
+          <BLOOD-PINTS-REPLACED>9999</BLOOD-PINTS-REPLACED>
+          <SEQUENCE-COUNTER>999</SEQUENCE-COUNTER>
+          <BILL-SOURCE>9</BILL-SOURCE>
+          <BENEFITS-EXHAUST-IND>8</BENEFITS-EXHAUST-IND>
+          <BENEFITS-PAY-IND>7</BENEFITS-PAY-IND>
+          <AUTO-ADJUSTMENT-IND>X</AUTO-ADJUSTMENT-IND>
+          <INTERMEDIARY-CTRL-NUM>A12345678901234567890AB</INTERMEDIARY-CTRL-NUM>
+        </ex:RECORD>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
+
+</testSuite>


### PR DESCRIPTION
Better illustration of Cobol capabilities.

Requires a daffodil 3.5.0 snapshot with the 'V' feature.