### PR TITLE
Version 0.0.2-SNAPSHOT: Fixed leading sign on zoned error.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,15 +2,14 @@ name := "dfdl-cobol-examples"
 
 organization := "com.owl"
 
-version := "0.0.1-SNAPSHOT"
+version := "0.0.2-SNAPSHOT"
 
 scalaVersion := "2.12.18"
- 
+
 libraryDependencies ++= Seq(
-  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.5.0" % "test",
+  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.7.0-SNAPSHOT" % "test",
   "junit" % "junit" % "4.13.2" % "test",
   "com.github.sbt" % "junit-interface" % "0.13.3" % "test",
-  "org.apache.logging.log4j" % "log4j-core" % "2.19.0" % "test",
 )
 
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")
@@ -27,7 +26,6 @@ useCoursier := false
 // file of the github openDFDL ibm-dfdl-crosstester project.
 //
 // IBMDFDLCrossTesterPlugin.settings
-
 
 //
 // Use flatter simple folder structure.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.9.0
+sbt.version=1.9.8
 

--- a/src/cobol1.dfdl.xsd
+++ b/src/cobol1.dfdl.xsd
@@ -66,8 +66,13 @@
       </annotation>
       <element name="CLAIM-NUMBER" type="xs:string" dfdl:length="19"/>
       <element name="ADMISSION-DATE" type="tns:date6Chars"/>
-      <element name="FROM-DATE" type="tns:date6Chars"/>
-      <element name="THRU-DATE" type="tns:date6Chars"/>
+      <!--
+      COBOL doesn't actually have a date type, but it is natural
+      to want to parse this data into a DFDL date type, so a couple of these
+      date fields use a type derived from DFDL's xs:date type.
+      -->
+      <element name="FROM-DATE" type="tns:date6CharsAsDate"/>
+      <element name="THRU-DATE" type="tns:date6CharsAsDate"/>
       <element name="DISCHARGE-DATE" type="tns:date6Chars"/>
       <element name="FULL-DAYS" type="tns:signedPackedInt5Digits"/>
       <element name="COINSURANCE-DAYS" type="tns:binary4Digits"/>
@@ -94,6 +99,27 @@
               dfdl:decimalSigned="yes"
               dfdl:length="6">
     <restriction base="xs:string" />
+  </simpleType>
+
+  <simpleType name="date6CharsAsDate"
+              dfdl:representation="text"
+              dfdl:calendarPatternKind="explicit"
+              dfdl:calendarPattern="MMddyy"
+              dfdl:calendarCenturyStart="50"
+              dfdl:calendarTimeZone=""
+              dfdl:length="6">
+    <!--
+    dfdl:calendarCenturyStart="50"
+    means if year is 49 or less it will be assumed century 2000.
+    if year is 50 to 99 it will be assumed century 1900
+    -->
+    <restriction base="xs:date">
+      <!-- These facets are not supported yet: JIRA DAFFODIL-2671 -->
+      <!--
+      <minInclusive value="1950-01-01"/>
+      <maxInclusive value="2049-12-31"/>
+      -->
+    </restriction>
   </simpleType>
   
   <simpleType name="signedPackedInt5Digits"
@@ -175,7 +201,8 @@
   <!--
   This type uses dfdl:textNumberPattern character 'V' for virtual decimal point
 
-  It is zoned decimal with trailing overpunched sign.
+  It is zoned decimal with leading overpunched sign. The character set is ebcdic, not ascii.
+  So dfdl:textZonedSignStyle property is not needed.
 
   This is not officially available until Daffodil 3.5.0
   -->
@@ -184,9 +211,9 @@
     name="displayMoney7Digits"
     dfdl:representation="text"
     dfdl:textNumberRep="zoned"
-    dfdl:textZonedSignStyle="asciiStandard"
+    dfdl:encoding="ebcdic-cp-us"
     dfdl:decimalSigned="yes"
-    dfdl:textNumberPattern="0000000V00+"
+    dfdl:textNumberPattern="+0000000V00"
     dfdl:length="9">
     <restriction base="xs:decimal" >
       <maxInclusive value="9999999.99"/>

--- a/src/cobolFormat1.dfdl.xsd
+++ b/src/cobolFormat1.dfdl.xsd
@@ -8,7 +8,7 @@
   xmlns:ex="http://example.com"
   xmlns:fn="http://www.w3.org/2005/xpath-functions">
 
-  <include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd"/>
 
   <annotation>
     <appinfo source="http://www.ogf.org/dfdl/">
@@ -29,6 +29,7 @@
                      textBooleanJustification="left"
                      textBooleanTrueRep="%#r00;"
                      textCalendarPadCharacter="0"
+                     textCalendarJustification="right"
                      textNumberJustification="right"
                      textNumberPadCharacter="0"
                      textNumberRep="zoned"
@@ -37,11 +38,47 @@
                      textPadKind="none"
                      textStandardBase="10"
                      textStandardZeroRep=""
-                     textTrimKind="none"
-                     textZonedSignStyle="asciiStandard">
+                     textStringJustification="left"
+                     textTrimKind="none">
+          <!--
+          Property textZonedSignStyle is not needed because encoding is ebcdic-cp-us and that property
+          only applies for ascii-derived encodings.
+          -->
         </dfdl:format>
       </dfdl:defineFormat>
       <dfdl:format ref="tns:cobol1Format"/>
     </appinfo>
   </annotation>
+
+  <!-- DISPLAY is text with single byte characters. PIC give lengths and string vs. numeric type.
+   Strings use X - any character, A for alphabetic only. Numbers use 9.
+   For DISPLAY numbers, by default it is overpunched trailing sign (when S indicates a sign).
+   SIGN SEPARATE LEADING/TRAILING can be specified for regular sign.
+   A real decimal point in the pattern will be expected in the data. P and V are used for implied decimal point.
+   -->
+  <!-- DISPLAY-1 is text with double-byte characters (zOS uses EBCDIC, others may be ASCII) -->
+  <!-- NATIONAL is text with UTF-16 characters (2 bytes)
+  TBD: can zoned numbers be represented? How does overpunched sign work in UTF-16
+  -->
+  <!-- COMP-1 is binary xs:float -->
+  <!-- COMP-2 is binary xs:double -->
+  <!-- COMP-3 is packed decimal. Maximum of 31 digits (38 in Micro Focus Cobol)
+  If unsigned, final sign nibble is F -->
+  <!-- BINARY, COMP, COMP-4 is two's complement, 2, 4, or 8 bytes depending on number of digits in PIC
+   which may have P or V to indicate scaling. Ranges of numbers are constrained by PIC digits.
+   Ex with V is COMP PIC S99V99 which has range of values from -99.99 to +99.99.
+    -->
+  <!-- COMP-5 is "native binary" i.e., two's complement, but allows full range of binary values.
+       So PIC S9999 has range -32768 to +32767, and PIC 9999 has range 0 to 65535.
+       Ex with V is COMP-5 PIC S99V99 which has range of values from -327.68 to +327.67.
+  -->
+  <!-- COMP-6 is BCD (no sign nibble) if unsigned, and packed-decimal if signed.
+  Not all cobol flavors support COMP-6.
+   -->
+  <!-- COMP-X is always unsigned (PIC may not contain S) and always stored big-endian order regardless of the
+  machine and compiler. Like COMP-5 it uses two's complement, and the full binary range of values.
+  The PIC using X is defining bytes, not digits, so COMP-X PIC X(5) is a 5 byte unsigned integer.
+  -->
+
+
 </schema>

--- a/test/tests.scala
+++ b/test/tests.scala
@@ -17,5 +17,4 @@ class Tests {
 
   @Test def testCobol1 { runner.runOneTest("testCobol1") }
 
-
 }

--- a/test/tests.tdml
+++ b/test/tests.tdml
@@ -8,7 +8,8 @@
   xmlns:ex="http://example.com"
   xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
   defaultConfig="cfg"
-  defaultRoundTrip="onePass">
+  defaultRoundTrip="onePass"
+  defaultValidation="limited">
 
   <defineConfig name="cfg">
     <daf:tunables>
@@ -22,13 +23,14 @@
     </daf:tunables>
   </defineConfig>
 
-  <parserTestCase name="testCobol1" model="cobol1.dfdl.xsd">
+  <parserTestCase name="testCobol1" model="cobol1.dfdl.xsd"
+    roundTrip="twoPass">
     <document>
       <documentPart type="text" encoding="ebcdic-cp-us">1234567890123456789</documentPart>
       <documentPart type="text" encoding="ebcdic-cp-us">020161</documentPart>
       <documentPart type="text" encoding="ebcdic-cp-us">020161</documentPart>
-      <documentPart type="text" encoding="ebcdic-cp-us">020161</documentPart>
-      <documentPart type="text" encoding="ebcdic-cp-us">123199</documentPart>
+      <documentPart type="text" encoding="ebcdic-cp-us">020106</documentPart>
+      <documentPart type="text" encoding="ebcdic-cp-us">020106</documentPart>
       <documentPart type="byte">99999C</documentPart>
       <documentPart type="byte">270f</documentPart>
       <documentPart type="byte">000f423f</documentPart>
@@ -36,14 +38,16 @@
       <documentPart type="text" encoding="ebcdic-cp-us">PROVIDER12345</documentPart>
       <documentPart type="byte">0999999C</documentPart>
       <documentPart type="byte">0999999C</documentPart>
-      <documentPart type="text" encoding="ebcdic-cp-us">99999999y</documentPart>
+      <!-- note leading overpunched sign below. The 'R' means -9 as the digit in EBCDIC. -->
+      <!-- Fix for DAFFODIL-2873 (Daffodil 3.7.0 or above) is required for ebcdic overpunched signs -->
+      <documentPart type="text" encoding="ebcdic-cp-us">R99999999</documentPart>
       <documentPart type="text" encoding="ebcdic-cp-us">AA</documentPart>
       <documentPart type="byte">0001869f</documentPart>
       <documentPart type="byte">270f</documentPart>
       <documentPart type="byte">03e7</documentPart>
-      <documentPart type="byte">F9</documentPart>
-      <documentPart type="byte">F8</documentPart>
-      <documentPart type="byte">F7</documentPart>
+      <documentPart type="byte">C9</documentPart>
+      <documentPart type="byte">C8</documentPart>
+      <documentPart type="byte">F7</documentPart><!-- TwoPass because this F7 is canonicalized to C7 by unparsing -->
       <documentPart type="text" encoding="ebcdic-cp-us">X</documentPart>
       <documentPart type="text" encoding="ebcdic-cp-us">A12345678901234567890AB</documentPart>
     </document>
@@ -52,9 +56,9 @@
         <ex:RECORD xmlns="">
           <CLAIM-NUMBER>1234567890123456789</CLAIM-NUMBER>
           <ADMISSION-DATE>020161</ADMISSION-DATE>
-          <FROM-DATE>020161</FROM-DATE>
-          <THRU-DATE>020161</THRU-DATE>
-          <DISCHARGE-DATE>123199</DISCHARGE-DATE>
+          <FROM-DATE>1961-02-01</FROM-DATE>
+          <THRU-DATE>2006-02-01</THRU-DATE>
+          <DISCHARGE-DATE>020106</DISCHARGE-DATE>
           <FULL-DAYS>99999</FULL-DAYS>
           <COINSURANCE-DAYS>9999</COINSURANCE-DAYS>
           <LIFETIME-RES-DAYS>999999</LIFETIME-RES-DAYS>


### PR DESCRIPTION
The COBOL says SIGN LEADING On the TOTAL-CHARGES field. It was using default trailing sign. Changed this and the test data. This was not only leading/trailing inverted, but it had 'y' as the expected sign character, which is the asciiStandard convention for -9 digit. This schema and test data is ebcdic however, so that character should be 'R'.

That lead to discovery of DAFFODIL-2873 - that zoned ebcdic overpunched signs do not work.

Hence, this example now requires daffodil version 3.7.0 or higher, (or a 3.7.0-SNAPSHOT build with the fix for DAFFODIL-2873)

Added example of using xs:date instead of treating date as strings. COBOL has no date data type, but it is natural to want to use DFDL date/time types so the parsed output XML/JSON/Other creates a date type.

Added comments about the COBOL types and PIC clauses as guidance for COBOL users who encounter such combinations.

Update sbt to latest.

Update Daffodil to 3.7.0-SNAPSHOT as this is required for the fix to DAFFODIL-2873 (fixes zoned ebcdic overpunched signs).

https://github.com/DFDLSchemas/Cobol/issues/7